### PR TITLE
Fix typeOf for node 14

### DIFF
--- a/src/rgbquant.js
+++ b/src/rgbquant.js
@@ -792,7 +792,11 @@
 	}
 
 	function typeOf(val) {
-		return Object.prototype.toString.call(val).slice(8,-1);
+		if (val && val.constructor && val.constructor.name) {
+			return val.constructor.name;
+		} else {
+			return Object.prototype.toString.call(val).slice(8,-1);
+		}
 	}
 
 	var sort = isArrSortStable() ? Array.prototype.sort : stableSort;


### PR DESCRIPTION
The previous implementation is only returning "Object" for me since toString returns "[object Object]"
Therefore, it is now doing the correct thing by looking at the constructor name.

This works with node 14, but I haven't tested it anywhere else.
However I've left the old implementation in place if there are cases where it may make sense. Whatever that might be